### PR TITLE
Content type for PROPFIND responses.

### DIFF
--- a/ngx_http_dav_ext_module.c
+++ b/ngx_http_dav_ext_module.c
@@ -672,7 +672,7 @@ ngx_http_dav_ext_propfind_handler(ngx_http_request_t *r)
 		ngx_str_set(&r->headers_out.status_line, "207 Multi-Status");
 
 		/* Add application/xml header required by RFC 4918. */
-                ngx_str_set(&r->headers_out.content_type, "application/xml");
+		ngx_str_set(&r->headers_out.content_type, "application/xml");
 
 		ngx_http_send_header(r);
 

--- a/ngx_http_dav_ext_module.c
+++ b/ngx_http_dav_ext_module.c
@@ -671,6 +671,9 @@ ngx_http_dav_ext_propfind_handler(ngx_http_request_t *r)
 
 		ngx_str_set(&r->headers_out.status_line, "207 Multi-Status");
 
+		/* Add application/xml header required by RFC 4918. */
+                ngx_str_set(&r->headers_out.content_type, "application/xml");
+
 		ngx_http_send_header(r);
 
 		ngx_http_finalize_request(r, ngx_http_dav_ext_send_propfind(r));


### PR DESCRIPTION
We've spotted a shortfall in the PROPFIND responses. They have no Content-Type header set.

>   I've attached a patch for ngx_http_dav_ext_module.c that sets a Content-Type: application/xml
>   header when I believe the output will always be XML. The absence of this 
>   header is what prevents the Perl HTTP::DAV client from working. 
>   AFAICT, with reference to RFC 4918, this header is required. See:
>   http://www.webdav.org/specs/rfc4918.html#rfc.section.8.2
