### PR TITLE
fix DAV class from 2 to 1,2 (like apache)

### DIFF
--- a/ngx_http_dav_ext_module.c
+++ b/ngx_http_dav_ext_module.c
@@ -502,8 +502,16 @@ ngx_http_dav_ext_content_handler(ngx_http_request_t *r)
         }
 
         ngx_str_set(&h->key, "DAV");
-        h->value.len = 1;
-        h->value.data = (u_char *) (dlcf->shm_zone ? "2" : "1");
+
+        if (dlcf->shm_zone) {
+            h->value.len = 3;
+           h->value.data = (u_char *) "1,2";
+        } 
+        else {
+           h->value.len = 1;
+           h->value.data = (u_char *) "1";
+        }
+
         h->hash = 1;
 
         h = ngx_list_push(&r->headers_out.headers);


### PR DESCRIPTION
I have found that most clients require a dav class1 to work

For example, davfs2 or fuse-wdfs check class1 and if they don't find it, they write it. 

/sbin/mount.davfs: mounting failed; the server does not support WebDAV
 
I checked with wireshark that the lua-nginx-module puts the header "dav"="2" while the apache server puts the header "dav"="1,2" and therefore davfs and wdfs work with apache without problems and do not work with nginx. 

The proposed patch displays the dav version as well as apache. 
